### PR TITLE
Make Mat4 Identity() different from .Zeros

### DIFF
--- a/mat4.go
+++ b/mat4.go
@@ -97,10 +97,10 @@ func Zeros() Mat4 {
 // `Identity` returns a 4x4 Identity matrix.
 func Identity() Mat4 {
 	return MakeMat4(
-		0, 0, 0, 0,
-		0, 0, 0, 0,
-		0, 0, 0, 0,
-		0, 0, 0, 0,
+		1, 0, 0, 0,
+		0, 1, 0, 0,
+		0, 0, 1, 0,
+		0, 0, 0, 1,
 	)
 }
 


### PR DESCRIPTION
Mat4's Identity() function was returning a 4x4 zeroed matrix; this would change it to return an identity matrix.
